### PR TITLE
Fix double free of abstract mem ranges

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -543,6 +543,8 @@ static void riscv_deinit_target(struct target *target)
 		free(range);
 		range = nrange;
 	}
+	/* ranges are global (one list for all riscv targets), so deallocate only once: */
+	riscv_abstract_mem_range = NULL;
 	//===========================================
 
 	target->arch_info = NULL;


### PR DESCRIPTION
Avoid double `free()` of `riscv_abstract_mem_range`.