### PR TITLE
Backported two system bus related fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ To obtain statically linked OpenOCD binary (which does not require additional DL
  
  ## Changelog
 
- - v2020\_01\_27: Commands "expose\_csrs" and "expose\_custom" were improved - changes backported from riscv-openocd
+ - v2021\_02\_11: Backported two system bus related fixes from riscv-openocd - original commits: 5d0543c, 9e17460
+ - v2021\_01\_27: Commands "expose\_csrs" and "expose\_custom" were improved - changes backported from riscv-openocd
    (cherry-picked commits [11c4f89b3](https://github.com/riscv/riscv-openocd/commit/11c4f89b32536de6d67264812bd7418433bd863b) and [6db3ed2c8](https://github.com/riscv/riscv-openocd/commit/6db3ed2c862e04588bf80758acb463a14e9b5ff5)). Fixed a minor free() related bug.
  - v2020\_09\_21: This repository has been obsoleted. Upstream "riscv-openocd" shall be used instead.
  - v2020\_07\_16: Fixed abstracts commands not to set `aampostincrement` bit, necessary since SweRV EH1 1.7

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -2610,7 +2610,7 @@ static int read_memory_bus_v1(struct target *target, target_addr_t address,
 
 		if (get_field(sbcs_read, DMI_SBCS_SBBUSYERROR)) {
 			/* We read while the target was busy. Slow down and try again. */
-			if (dmi_write(target, DMI_SBCS, DMI_SBCS_SBBUSYERROR) != ERROR_OK)
+			if (dmi_write(target, DMI_SBCS, sbcs_read | DMI_SBCS_SBBUSYERROR) != ERROR_OK)
 				return ERROR_FAIL;
 			next_address = sb_read_address(target);
 			info->bus_master_read_delay += info->bus_master_read_delay / 10 + 1;
@@ -3487,6 +3487,8 @@ static int write_memory_bus_v1(struct target *target, target_addr_t address,
 				target,
 				32,
 				info->dmi_busy_delay + info->bus_master_write_delay);
+		if (!batch)
+			return ERROR_FAIL;
 
 		for (uint32_t i = (next_address - address) / size; i < count; i++) {
 			const uint8_t *p = buffer + i * size;
@@ -3526,54 +3528,76 @@ static int write_memory_bus_v1(struct target *target, target_addr_t address,
 			next_address += size;
 		}
 
+		/* Execute the batch of writes */
 		result = batch_run(target, batch);
 		riscv_batch_free(batch);
 		if (result != ERROR_OK)
 			return result;
 
+		/* Read sbcs value.
+		 * At the same time, detect if DMI busy has occurred during the batch write. */
 		bool dmi_busy_encountered;
 		if (dmi_op(target, &sbcs, &dmi_busy_encountered, DMI_OP_READ,
-				DMI_SBCS, 0, false, false) != ERROR_OK)
+				DMI_SBCS, 0, false, true) != ERROR_OK)
 			return ERROR_FAIL;
+		if (dmi_busy_encountered)
+			LOG_DEBUG("DMI busy encountered during system bus write.");
 
+		/* Wait until sbbusy goes low */
 		time_t start = time(NULL);
-		bool dmi_busy = dmi_busy_encountered;
-		while (get_field(sbcs, DMI_SBCS_SBBUSY) || dmi_busy) {
+		while (get_field(sbcs, DMI_SBCS_SBBUSY)) {
 			if (time(NULL) - start > riscv_command_timeout_sec) {
 				LOG_ERROR("Timed out after %ds waiting for sbbusy to go low (sbcs=0x%x). "
-					  "Increase the timeout with riscv set_command_timeout_sec.",
-					  riscv_command_timeout_sec, sbcs);
+						  "Increase the timeout with riscv set_command_timeout_sec.",
+						  riscv_command_timeout_sec, sbcs);
 				return ERROR_FAIL;
 			}
-
-			if (dmi_op(target, &sbcs, &dmi_busy, DMI_OP_READ,
-						DMI_SBCS, 0, false, true) != ERROR_OK)
+			if (dmi_read(target, &sbcs, DMI_SBCS) != ERROR_OK)
 				return ERROR_FAIL;
 		}
 
 		if (get_field(sbcs, DMI_SBCS_SBBUSYERROR)) {
-			/* We wrote while the target was busy. Slow down and try again. */
-			dmi_write(target, DMI_SBCS, DMI_SBCS_SBBUSYERROR);
+			/* We wrote while the target was busy. */
+			LOG_DEBUG("Sbbusyerror encountered during system bus write.");
+			/* Clear the sticky error flag. */
+			dmi_write(target, DMI_SBCS, sbcs | DMI_SBCS_SBBUSYERROR);
+			/* Slow down before trying again. */
 			info->bus_master_write_delay += info->bus_master_write_delay / 10 + 1;
 		}
 
 		if (get_field(sbcs, DMI_SBCS_SBBUSYERROR) || dmi_busy_encountered) {
+			/* Recover from the case when the write commands were issued too fast.
+			 * Determine the address from which to resume writing. */
 			next_address = sb_read_address(target);
 			if (next_address < address) {
 				/* This should never happen, probably buggy hardware. */
-				LOG_DEBUG("unexpected system bus address 0x%" TARGET_PRIxADDR,
-					  next_address);
+				LOG_DEBUG("unexpected sbaddress=0x%" TARGET_PRIxADDR
+						  " - buggy sbautoincrement in hw?", next_address);
+				/* Fail the whole operation. */
 				return ERROR_FAIL;
 			}
-
+			/* Try again - resume writing. */
 			continue;
 		}
 
-		unsigned error = get_field(sbcs, DMI_SBCS_SBERROR);
-		if (error != 0) {
-			/* Some error indicating the bus access failed, but not because of
-			 * something we did wrong. */
+		unsigned sberror = get_field(sbcs, DMI_SBCS_SBERROR);
+		if (sberror != 0) {
+			/* Sberror indicates the bus access failed, but not because we issued the writes
+			 * too fast. Cannot recover. Sbaddress holds the address where the error occurred
+			 * (unless sbautoincrement in the HW is buggy).
+			 */
+			target_addr_t sbaddress = sb_read_address(target);
+			LOG_DEBUG("System bus access failed with sberror=%u (sbaddress=0x%" TARGET_PRIxADDR ")",
+					  sberror, sbaddress);
+			if (sbaddress < address) {
+				/* This should never happen, probably buggy hardware.
+				 * Make a note to the user not to trust the sbaddress value. */
+				LOG_DEBUG("unexpected sbaddress=0x%" TARGET_PRIxADDR
+						  " - buggy sbautoincrement in hw?", next_address);
+			}
+			/* Clear the sticky error flag */
 			dmi_write(target, DMI_SBCS, DMI_SBCS_SBERROR);
+			/* Fail the whole operation */
 			return ERROR_FAIL;
 		}
 	}


### PR DESCRIPTION
Fix 1: Clear sbcs.sbbusyerror without affecting other sbcs bits
- This allows system bus read/write to continue properly even if sbbusyerror is encountered in the process
- Original upstream commit in riscv-openocd: 5d0543c

Fix 2: Read sbcs properly in write_memory_bus_v1()
- This allows to detect errors (sbcs.sberror) that may occur in write_memory_bus_v1()
- Original upstream commit in riscv-openocd: 9e17460